### PR TITLE
[COOK-1649] Fix typo in default attributes.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,2 @@
 default['tmux']['version'] = '1.6'
-default['tmxu']['checksum'] = '8756f6bcecb18102b87e5d6f5952ba2541f68ed3'
+default['tmux']['checksum'] = '8756f6bcecb18102b87e5d6f5952ba2541f68ed3'


### PR DESCRIPTION
- Fix typo in attributes/default.rb
