### PR TITLE
Add attribute that can be used to control tmux source code url

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,7 @@ default['tmux']['install_method'] = case node['platform_family']
                                       'package'
                                     end
 
+default['tmux']['source_url'] = 'http://downloads.sourceforge.net/tmux'
 default['tmux']['version'] = '1.8'
 default['tmux']['checksum'] = 'f265401ca890f8223e09149fcea5abcd6dfe75d597ab106e172b01e9d0c9cd44'
 

--- a/recipes/_source.rb
+++ b/recipes/_source.rb
@@ -31,7 +31,7 @@ end
 
 tar_name = "tmux-#{node['tmux']['version']}"
 remote_file "#{Chef::Config['file_cache_path']}/#{tar_name}.tar.gz" do
-  source   "http://downloads.sourceforge.net/tmux/#{tar_name}.tar.gz"
+  source   "#{node['tmux']['source_url']}/#{tar_name}.tar.gz"
   checksum node['tmux']['checksum']
   notifies :run, 'bash[install_tmux]', :immediately
 end


### PR DESCRIPTION
Sourceforge is broken right now but, more importantly, it's nice for a user to be able to specify where they want to store this source code (e.g. reliable S3 storage or otherwise for enterprise reliability).